### PR TITLE
修复解压加密文件，总是少12个字节的问题

### DIFF
--- a/Zip/zip/unzip.cpp
+++ b/Zip/zip/unzip.cpp
@@ -3614,7 +3614,7 @@ int unzReadCurrentFile(unzFile file, voidp buf, unsigned len, bool *reached_eof)
 		if (uDoEncHead>0)
 		{
 			char bufcrc = pfile_in_zip_read_info->stream.next_in[uDoEncHead - 1];
-			pfile_in_zip_read_info->rest_read_uncompressed -= uDoEncHead;
+			//pfile_in_zip_read_info->rest_read_uncompressed -= uDoEncHead;
 			pfile_in_zip_read_info->stream.avail_in -= uDoEncHead;
 			pfile_in_zip_read_info->stream.next_in += uDoEncHead;
 			pfile_in_zip_read_info->encheadleft -= uDoEncHead;


### PR DESCRIPTION
原来的程序在解压加密的压缩包时，解压出来的文件总是会少12个字节。
问题出在：unzip.cpp ->Line 3617 ->rest_read_uncompressd 总是减少了 uDoEncHead，注释掉后就正常了。
现在已将此问题修复。